### PR TITLE
Changed Math.min() to Math.max() in nextflow.config for the number of max cpus check

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -125,7 +125,7 @@ def check_max(obj, type) {
     }
   } else if(type == 'cpus'){
     try {
-      return Math.min( obj, params.max_cpus as int )
+      return Math.max( obj, params.max_cpus as int )
     } catch (all) {
       println "   ### ERROR ###   Max cpus '${params.max_cpus}' is not valid! Using default value: $obj"
       return obj


### PR DESCRIPTION
When using Math.min(), the number of max cpus is always 1 (1 * task.attempt).